### PR TITLE
add post-syseeprom  scripts to pmon

### DIFF
--- a/sonic-post-syseeprom/scripts/post-syseeprom
+++ b/sonic-post-syseeprom/scripts/post-syseeprom
@@ -1,0 +1,43 @@
+#!/usr/bin/env python2
+
+'''
+    post-syseeprom
+    Syseeprom infomation gathering task for SONiC
+    This task will be started during the start phase of pmon container, gathering syseeprom info and write to state DB.
+    It's an one-shot task since syseeprom info are static.
+    With this task, show syseeprom CLI will be able to get data from state DB instead of access hw or cache.
+'''
+
+try:
+    from sonic_daemon_base.daemon_base import DaemonBase
+except ImportError, e:
+    raise ImportError (str(e) + " - required module not found")
+
+PLATFORM_SPECIFIC_MODULE_NAME = 'eeprom'
+PLATFORM_SPECIFIC_CLASS_NAME = 'board'
+
+def main():
+    Daemon_Base = DaemonBase()
+    (platform_path, hwsku_path) = Daemon_Base.get_path_to_platform_and_hwsku()
+    
+    # Arista platform have their own implementation for eeprom tlv parsing, it's not inherited from eeprom base class.
+    # So for now this task can not support Arista platform, but this will not cause anny issue on them. 
+    # decode-syseeprom scripts will cover Arista case, it will still read from hw/cache instead from DB on Arista platform.  
+    if 'arista' in platform_path:
+        Daemon_Base.log_warning('Arista platform not support this yet')
+        return 1
+    
+    eeprom_util = Daemon_Base.load_platform_util(PLATFORM_SPECIFIC_MODULE_NAME, PLATFORM_SPECIFIC_CLASS_NAME)
+
+    eeprom = eeprom_util.read_eeprom()
+    if eeprom is None :
+        Daemon_Base.log_error('Failed to read eeprom')
+        return 2
+
+    err = eeprom_util.update_eeprom_db(eeprom)
+    if err:
+        Daemon_Base.log_error('Failed to update eeprom to database')
+        return 3
+
+if __name__ == '__main__':
+    main()

--- a/sonic-post-syseeprom/scripts/post-syseeprom
+++ b/sonic-post-syseeprom/scripts/post-syseeprom
@@ -16,6 +16,10 @@ except ImportError, e:
 PLATFORM_SPECIFIC_MODULE_NAME = 'eeprom'
 PLATFORM_SPECIFIC_CLASS_NAME = 'board'
 
+ERR_ARISTA_PLATFORM = 1
+ERR_FAILED_EEPROM = 2
+ERR_FAILED_UPDATE_DB = 3
+
 def main():
     Daemon_Base = DaemonBase()
     (platform_path, hwsku_path) = Daemon_Base.get_path_to_platform_and_hwsku()
@@ -25,19 +29,19 @@ def main():
     # decode-syseeprom scripts will cover Arista case, it will still read from hw/cache instead from DB on Arista platform.  
     if 'arista' in platform_path:
         Daemon_Base.log_warning('Arista platform not support this yet')
-        return 1
+        return ERR_ARISTA_PLATFORM
     
     eeprom_util = Daemon_Base.load_platform_util(PLATFORM_SPECIFIC_MODULE_NAME, PLATFORM_SPECIFIC_CLASS_NAME)
 
     eeprom = eeprom_util.read_eeprom()
     if eeprom is None :
         Daemon_Base.log_error('Failed to read eeprom')
-        return 2
+        return ERR_FAILED_EEPROM
 
     err = eeprom_util.update_eeprom_db(eeprom)
     if err:
         Daemon_Base.log_error('Failed to update eeprom to database')
-        return 3
+        return ERR_FAILED_UPDATE_DB
 
 if __name__ == '__main__':
     main()

--- a/sonic-post-syseeprom/setup.py
+++ b/sonic-post-syseeprom/setup.py
@@ -1,0 +1,29 @@
+from setuptools import setup
+
+setup(
+    name='sonic-post-syseeprom',
+    version='1.0',
+    description='Syseeprom gathering task for SONiC',
+    license='Apache 2.0',
+    author='SONiC Team',
+    author_email='linuxnetdev@microsoft.com',
+    url='https://github.com/Azure/sonic-platform-daemons',
+    maintainer='Kebo Liu',
+    maintainer_email='kebol@mellanox.com',
+    scripts=[
+        'scripts/post-syseeprom',
+    ],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: No Input/Output (Daemon)',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: System :: Hardware',
+    ],
+    keywords='sonic SONiC SYSEEPROM syseeprom POST-SYSEEPROM post-syseeprom',
+)


### PR DESCRIPTION
Add post-syseeprom script to pmon.
This script intends to gather syseeprom and write to state DB.