### PR TITLE
[xcvrd] Extend xcvrd with SFP error event handling

### DIFF
--- a/sonic-xcvrd/scripts/xcvrd
+++ b/sonic-xcvrd/scripts/xcvrd
@@ -33,6 +33,7 @@ PLATFORM_SPECIFIC_CLASS_NAME = "SfpUtil"
 
 TRANSCEIVER_INFO_TABLE = 'TRANSCEIVER_INFO'
 TRANSCEIVER_DOM_SENSOR_TABLE = 'TRANSCEIVER_DOM_SENSOR'
+TRANSCEIVER_ERROR_TABLE = 'TRANSCEIVER_ERROR'
 
 SELECT_TIMEOUT_MSECS = 1000
 
@@ -40,8 +41,18 @@ DOM_INFO_UPDATE_PERIOD_SECS = 60
 TIME_FOR_SFP_READY_SECS = 1
 XCVRD_MAIN_THREAD_SLEEP_SECS = 60
 
-SFP_STATUS_INSERTED = '1'
+# SFP status definition, shall be aligned with the definition in get_change_event() of ChassisBase
 SFP_STATUS_REMOVED = '0'
+SFP_STATUS_INSERTED = '1'
+SFP_STATUS_ERR_I2C_STUCK = '2'
+SFP_STATUS_ERR_BAD_EEPROM = '3'
+SFP_STATUS_ERR_UNSUPPORTED_CABLE = '4'
+SFP_STATUS_ERR_HIGH_TEMP = '5'
+SFP_STATUS_ERR_BAD_CABLE = '6'
+
+error_block_eeprom_list = [SFP_STATUS_ERR_I2C_STUCK, SFP_STATUS_ERR_BAD_EEPROM,
+                           SFP_STATUS_ERR_UNSUPPORTED_CABLE, SFP_STATUS_ERR_HIGH_TEMP,
+                           SFP_STATUS_ERR_BAD_CABLE]
 
 EVENT_ON_ALL_SFP = '-1'
 # events definition
@@ -411,15 +422,17 @@ def del_port_sfp_dom_info_from_db(logical_port_name, int_tbl, dom_tbl):
         ganged_member_num += 1
 
         try:
-            int_tbl._del(port_name)
-            dom_tbl._del(port_name)
+            if int_tbl != None:
+                int_tbl._del(port_name)
+            if dom_tbl != None:
+                dom_tbl._del(port_name)
 
         except NotImplementedError:
             logger.log_error("This functionality is currently not implemented for this platform")
             sys.exit(NOT_IMPLEMENTED_ERROR)
 
 # recover missing sfp table entries if any
-def recover_missing_sfp_table_entries(sfp_util, int_tbl, stop_event):
+def recover_missing_sfp_table_entries(sfp_util, int_tbl, err_tbl, stop_event):
     transceiver_dict = {}
     
     keys = int_tbl.getKeys()
@@ -427,7 +440,7 @@ def recover_missing_sfp_table_entries(sfp_util, int_tbl, stop_event):
     for logical_port_name in logical_port_list:
         if stop_event.is_set():
             break
-        if logical_port_name not in keys:
+        if logical_port_name not in keys and not detect_port_in_error_table(logical_port_name, err_tbl):
             post_port_sfp_info_to_db(logical_port_name, int_tbl, transceiver_dict, stop_event)
     
 
@@ -641,6 +654,23 @@ def waiting_time_compensation_with_sleep(time_start, time_to_wait):
     if time_diff < time_to_wait:
         time.sleep(time_to_wait - time_diff)
 
+# On receiving SFP error event, add related ports to error table
+def add_port_to_error_table_on_error_event(logical_port_name, err_tbl, error_state):
+    fvs = swsscommon.FieldValuePairs([('status', error_state)])
+    err_tbl.set(logical_port_name, fvs)
+
+# Remove port from error table when it restored from error status
+def remove_port_from_error_table(logical_port_name, err_tbl):
+    err_tbl._del(logical_port_name)
+
+# Check whether port in error table
+def detect_port_in_error_table(logical_port_name, err_tbl):
+    keys = err_tbl.getKeys()
+    if logical_port_name in keys:
+        return True
+    else:
+        return False
+
 #
 # Helper classes ===============================================================
 #
@@ -657,13 +687,15 @@ class dom_info_update_task:
         # Connect to STATE_DB and create transceiver dom info table
         state_db = daemon_base.db_connect(swsscommon.STATE_DB)
         dom_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
+        err_tbl = swsscommon.Table(state_db, TRANSCEIVER_ERROR_TABLE)
 
         # Start loop to update dom info in DB periodically
         while not self.task_stopping_event.wait(DOM_INFO_UPDATE_PERIOD_SECS):
             logical_port_list = platform_sfputil.logical
             for logical_port_name in logical_port_list:
-                post_port_dom_info_to_db(logical_port_name, dom_tbl, self.task_stopping_event)
-                post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl, self.task_stopping_event)
+                if not detect_port_in_error_table(logical_port_name, err_tbl):
+                    post_port_dom_info_to_db(logical_port_name, dom_tbl, self.task_stopping_event)
+                    post_port_dom_threshold_info_to_db(logical_port_name, dom_tbl, self.task_stopping_event)
 
         logger.log_info("Stop DOM monitoring loop")
 
@@ -716,6 +748,7 @@ class sfp_state_update_task:
         state_db = daemon_base.db_connect(swsscommon.STATE_DB)
         int_tbl = swsscommon.Table(state_db, TRANSCEIVER_INFO_TABLE)
         dom_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
+        err_tbl = swsscommon.Table(state_db, TRANSCEIVER_ERROR_TABLE)
 
         # Connect to APPL_DB to notify Media notifications
         appl_db = daemon_base.db_connect(swsscommon.APPL_DB)
@@ -846,6 +879,10 @@ class sfp_state_update_task:
                         for logical_port in logical_port_list:
                             if value == SFP_STATUS_INSERTED:
                                 logger.log_info("Got SFP inserted event")
+                                # A plugin event will clear the error state.
+                                if detect_port_in_error_table(logical_port, err_tbl):
+                                    remove_port_from_error_table(logical_port, err_tbl)
+                                    logger.log_info("receive plug in and remove port from error list ")
                                 rc = post_port_sfp_info_to_db(logical_port, int_tbl, transceiver_dict)
                                 # If we didn't get the sfp info, assuming the eeprom is not ready, give a try again.
                                 if rc == SFP_EEPROM_NOT_READY:
@@ -858,9 +895,24 @@ class sfp_state_update_task:
                                 transceiver_dict.clear()
                             elif value == SFP_STATUS_REMOVED:
                                 logger.log_info("Got SFP removed event")
+                                if detect_port_in_error_table(logical_port, err_tbl):
+                                    remove_port_from_error_table(logical_port, err_tbl)
+                                    logger.log_info("receive plug out and remove port from error list ")
                                 del_port_sfp_dom_info_from_db(logical_port, int_tbl, dom_tbl)
+                            elif value in error_block_eeprom_list:
+                                logger.log_info("Got SFP Error event")
+                                # Add port to error table to stop accessing eeprom of it
+                                # If the port already in the error table, the stored error code will
+                                # be updated to the new one.
+                                add_port_to_error_table_on_error_event(logical_port, err_tbl, value)
+                                logger.log_info("receive error add/update port to error list")
+                                # In this case EEPROM is not accessible, so remove the DOM info
+                                # since it will be outdated if long time no update.
+                                # but will keep the interface info in the DB since it static.
+                                del_port_sfp_dom_info_from_db(logical_port, None, dom_tbl)
+
                             else:
-                                # TODO, SFP return error code, need handle accordingly.
+                                # SFP return unkown event, just ignor for now.
                                 logger.log_warning("Got unknown event {}, ignored".format(value))
                                 continue
                 else:
@@ -1012,6 +1064,7 @@ class DaemonXcvrd(DaemonBase):
         state_db = daemon_base.db_connect(swsscommon.STATE_DB)
         self.int_tbl = swsscommon.Table(state_db, TRANSCEIVER_INFO_TABLE)
         self.dom_tbl = swsscommon.Table(state_db, TRANSCEIVER_DOM_SENSOR_TABLE)
+        self.err_tbl = swsscommon.Table(state_db, TRANSCEIVER_ERROR_TABLE)
 
         self.load_media_settings()
         warmstart = swsscommon.WarmStart()
@@ -1035,6 +1088,7 @@ class DaemonXcvrd(DaemonBase):
         logical_port_list = platform_sfputil.logical
         for logical_port_name in logical_port_list:
             del_port_sfp_dom_info_from_db(logical_port_name, self.int_tbl, self.dom_tbl)
+            remove_port_from_error_table(logical_port_name, self.err_tbl)
 
     # Run daemon
     def run(self):
@@ -1056,7 +1110,7 @@ class DaemonXcvrd(DaemonBase):
 
         while not self.stop_event.wait(self.timeout):
             # Check the integrity of the sfp info table and recover the missing entries if any
-            recover_missing_sfp_table_entries(platform_sfputil, self.int_tbl, self.stop_event)
+            recover_missing_sfp_table_entries(platform_sfputil, self.int_tbl, self.err_tbl, self.stop_event)
 
         logger.log_info("Stop daemon main loop")
 


### PR DESCRIPTION
Add SFP event handling logic to XCVRD, the main purpose is to stop accessing SFP EEPROM when some error event raised from SFP and which will block the EEPROM accessing.   

1.  When receive the error event on some SFP,  the related ports will be added to a new table which is to store the ports that on top of the error SFP, xcvrd will remove the DOM table and stop to update the DOM until SFP recovered from the error.  This is done by checking the new table before reading the DOM, if ports in error status, DOM update will be skipped.

2.  A plug in event received on the error SFP will be considered as this SFP is recovered from error status. 
