### PR TITLE
Support to get MEDIA_SETTING and OPTICS_SI from both platform folder and HWSKU folder

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -579,9 +579,13 @@ class TestXcvrdScript(object):
         task = SfpStateUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event, sfp_error_event)
         task._init_port_sfp_status_tbl(port_mapping, xcvr_table_helper, stop_event)
 
-    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/invalid/path', None)))
+    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/invalid/path', '/invalid/path')))
     def test_load_media_settings_missing_file(self):
         assert media_settings_parser.load_media_settings() == {}
+
+    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/invalid/path', '/invalid/path')))
+    def test_load_optical_si_settings_missing_file(self):
+        assert optics_si_parser.load_optics_si_settings() == {}
 
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd.is_cmis_api')
@@ -2445,6 +2449,22 @@ class TestXcvrdScript(object):
 
             xcvrd.init()
             xcvrd.deinit()
+
+    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=(test_path, '/invalid/path')))
+    def test_load_optical_si_file_from_platform_folder(self):
+        assert optics_si_parser.load_optics_si_settings() != {}
+
+    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/invalid/path', test_path)))
+    def test_load_optical_si_file_from_hwsku_folder(self):
+        assert optics_si_parser.load_optics_si_settings() != {}
+
+    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=(test_path, '/invalid/path')))
+    def test_load_media_settings_file_from_platform_folder(self):
+        assert media_settings_parser.load_media_settings() != {}
+
+    @patch('sonic_py_common.device_info.get_paths_to_platform_and_hwsku_dirs', MagicMock(return_value=('/invalid/path', test_path)))
+    def test_load_media_settings_file_from_hwsku_folder(self):
+        assert media_settings_parser.load_media_settings() != {}
 
 def wait_until(total_wait_time, interval, call_back, *args, **kwargs):
     wait_time = 0

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/media_settings_parser.py
@@ -22,10 +22,17 @@ helper_logger = logger.Logger(SYSLOG_IDENTIFIER)
 
 def load_media_settings():
     global g_dict
-    (platform_path, _) = device_info.get_paths_to_platform_and_hwsku_dirs()
+    (platform_path, hwsku_path) = device_info.get_paths_to_platform_and_hwsku_dirs()
 
-    media_settings_file_path = os.path.join(platform_path, "media_settings.json")
-    if not os.path.isfile(media_settings_file_path):
+    # Support to fetch media_settings.json both from platform folder and HWSKU folder
+    media_settings_file_path_platform = os.path.join(platform_path, "media_settings.json")
+    media_settings_file_path_hwsku = os.path.join(hwsku_path, "media_settings.json")
+
+    if os.path.isfile(media_settings_file_path_hwsku):
+        media_settings_file_path = media_settings_file_path_hwsku
+    elif os.path.isfile(media_settings_file_path_platform):
+        media_settings_file_path = media_settings_file_path_platform
+    else:
         helper_logger.log_info("xcvrd: No media file exists")
         return {}
 

--- a/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
+++ b/sonic-xcvrd/xcvrd/xcvrd_utilities/optics_si_parser.py
@@ -120,10 +120,17 @@ def fetch_optics_si_setting(physical_port, lane_speed, sfp):
 
 def load_optics_si_settings():
     global g_optics_si_dict
-    (platform_path, _) = device_info.get_paths_to_platform_and_hwsku_dirs()
+    (platform_path, hwsku_path) = device_info.get_paths_to_platform_and_hwsku_dirs()
 
-    optics_si_settings_file_path = os.path.join(platform_path, "optics_si_settings.json")
-    if not os.path.isfile(optics_si_settings_file_path):
+    # Support to fetch optics_si_settings.json both from platform folder and HWSKU folder
+    optics_si_settings_file_path_platform = os.path.join(platform_path, "optics_si_settings.json")
+    optics_si_settings_file_path_hwsku = os.path.join(hwsku_path, "optics_si_settings.json")
+
+    if os.path.isfile(optics_si_settings_file_path_hwsku):
+        optics_si_settings_file_path = optics_si_settings_file_path_hwsku
+    elif os.path.isfile(optics_si_settings_file_path_platform):
+        optics_si_settings_file_path = optics_si_settings_file_path_platform
+    else:
         helper_logger.log_info("No optics SI file exists")
         return {}
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
Support to get the media_settings.json and optics_si_settings.json files from both platform folder and SKU folder.
It will search the HWSKU folder first and then fallback to the platform folder.

#### Motivation and Context
The vendor will have the flexibility to have both files in the platform scope or the SKU scope.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

Build image, manually test,
1. put files in the platform folder, the settings should be able to be loaded.
2. put files in the SKU folder, the settings should be able to be loaded.
3. put the files in both platform and SKU folder, the settings in the SKU folder will be loaded. 

#### Additional Information (Optional)
